### PR TITLE
added toolname field to CodeQualityCreateRequest

### DIFF
--- a/src/main/java/com/capitalone/dashboard/request/CodeQualityCreateRequest.java
+++ b/src/main/java/com/capitalone/dashboard/request/CodeQualityCreateRequest.java
@@ -24,6 +24,8 @@ public class CodeQualityCreateRequest {
     @NotNull
     private String projectVersion;
 
+    private String toolName;
+
     private String niceName;
 
     private List<CodeQualityMetric> metrics = new ArrayList<>();
@@ -105,5 +107,13 @@ public class CodeQualityCreateRequest {
 
     public void setNiceName(String niceName) {
         this.niceName = niceName;
+    }
+
+    public String getToolName() {
+        return toolName;
+    }
+
+    public void setToolName(String toolName) {
+        this.toolName = toolName;
     }
 }


### PR DESCRIPTION
Referencing issue [Hygieia/Hygieia-#2577](https://github.com/Hygieia/Hygieia/issues/2577)

This PR adds a field called `toolName` to the `CodeQualityCreateRequest` class.
So, that hard-coded name `Sonar` can be modified as necessary.