### PR TITLE
update mongodb driver to 3.6 to support AWS DocumentDB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
         <maven.project-info.version>3.0.0</maven.project-info.version>
         <maven.scm.publish.plugin.version>3.0.0</maven.scm.publish.plugin.version>
         <maven.site.plugin.version>3.7.1</maven.site.plugin.version>
-        <mongo>3.0.2</mongo>
-        <mongodb.version>3.0.2</mongodb.version>
+        <mongo>3.6.4</mongo>
+        <mongodb.version>3.6.4</mongodb.version>
         <pmd.version>3.6</pmd.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <site.publish.url>https://github.com/Hygieia/hygieia-core</site.publish.url>
@@ -352,7 +352,7 @@
         <dependency>
             <groupId>com.github.fakemongo</groupId>
             <artifactId>fongo</artifactId>
-            <version>2.0.3</version>
+            <version>2.2.0-RC2</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <groupId>com.capitalone.dashboard</groupId>
     <artifactId>core</artifactId>
     <packaging>jar</packaging>
-    <version>3.7.23</version>
+    <version>3.7.24</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Core package shared by API layer and Microservices</description>
     <url>https://github.com/Hygieia/hygieia-core</url>


### PR DESCRIPTION
<!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
       http://www.apache.org/licenses/LICENSE-2.0
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-->
<!--
!!! For Security Vulnerabilities, please go to https://gitter.im/capitalone/Hygieia and find
    an active team memberl, request their email address, and email directly!!!
-->
**Affects:** \<hygieia-core-version-number>.

---
<!--
- For bugs, specify affected versions and explain what you are trying to do.
- For enhancements, provide context and describe the problem.

Issue or Pull Request? Create only one, not both. GitHub treats them as the same.
If unsure, start with an issue, and if you submit a pull request later, the
issue will be closed as superseded.
-->
Updating the mongodb driver library version to 3.6 in order to support AWS DocumentDB (which is MongoDB API 3.6 compatible)

There are some issues w/ Fongo but the latest version which is RC does seem to pass unit tests.  But it's not a great long term solution.  Ideally, probably need to move away from Fongo as it hasn't been updated in a while.