### PR TITLE
Spring Web Version Bump to Address Security Concern

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <logback.version>1.2.3</logback.version>
         <mongodb.version>3.6.4</mongodb.version>
         <assertj.version>3.9.0</assertj.version>
-        <springweb.version>5.2.9.RELEASE</springweb.version>
+        <springweb.version>5.2.18.RELEASE</springweb.version>
         <jaxbapi.version>2.2.12</jaxbapi.version>
 
         <!-- Plugins -->


### PR DESCRIPTION
Fixes #366 with a bump the latest spring web 5.2 released version which is 5.2.18

Signed-off-by: Ken Sipe <kensipe@gmail.com>

<!--
!!! For Security Vulnerabilities, please go to https://gitter.im/capitalone/Hygieia and find
    an active team memberl, request their email address, and email directly!!!
-->
**Affects:** \366.