### PR TITLE
Allow to specify authSource database

### DIFF
--- a/src/main/java/com/capitalone/dashboard/config/MongoConfig.java
+++ b/src/main/java/com/capitalone/dashboard/config/MongoConfig.java
@@ -27,6 +27,8 @@ public class MongoConfig extends AbstractMongoConfiguration {
 
     @Value("${dbname:dashboarddb}")
     private String databaseName;
+    @Value("${authsource:admin}")
+    private String authSource;    
     @Value("${dbhost:localhost}")
     private String host;
     @Value("${dbport:27017}")
@@ -83,7 +85,7 @@ public class MongoConfig extends AbstractMongoConfiguration {
                 client = new MongoClient(serverAddressList);
             } else {
                 MongoCredential mongoCredential = MongoCredential.createScramSha1Credential(
-                        userName, databaseName, password.toCharArray());
+                        userName, authSource, password.toCharArray());
                 client = new MongoClient(serverAddressList, Collections.singletonList(mongoCredential), opts);
             }
         } else {


### PR DESCRIPTION
<!--
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
   The ASF licenses this file to You under the Apache License, Version 2.0
   (the "License"); you may not use this file except in compliance with
   the License.  You may obtain a copy of the License at
       http://www.apache.org/licenses/LICENSE-2.0
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   See the License for the specific language governing permissions and
   limitations under the License.
-->
<!--
!!! For Security Vulnerabilities, please go to https://gitter.im/capitalone/Hygieia and find
    an active team memberl, request their email address, and email directly!!!
-->
**Affects:** master

---
This change allows user to specify different MongDb auth database than is the default "data holding" database.

<!--
- For bugs, specify affected versions and explain what you are trying to do.
- For enhancements, provide context and describe the problem.

Issue or Pull Request? Create only one, not both. GitHub treats them as the same.
If unsure, start with an issue, and if you submit a pull request later, the
issue will be closed as superseded.
-->


