### PR TITLE
Added read preference to read from secondary in mongo config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <groupId>com.capitalone.dashboard</groupId>
     <artifactId>core</artifactId>
     <packaging>jar</packaging>
-    <version>3.15.32</version>
+    <version>3.15.33</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Core package shared by API layer and Microservices</description>
     <url>https://github.com/Hygieia/hygieia-core</url>

--- a/src/main/java/com/capitalone/dashboard/config/MongoConfig.java
+++ b/src/main/java/com/capitalone/dashboard/config/MongoConfig.java
@@ -5,6 +5,7 @@ import com.mongodb.MongoClient;
 import com.mongodb.MongoClientOptions;
 import com.mongodb.MongoCredential;
 import com.mongodb.ServerAddress;
+import com.mongodb.ReadPreference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -66,6 +67,7 @@ public class MongoConfig extends AbstractMongoConfiguration {
         builder.serverSelectionTimeout(30000);          // MongoDB default 30 seconds
         builder.connectTimeout(dbConnectTimeout);       // MongoDB default varies, may be 10 seconds
         builder.socketTimeout(dbSocketTimeout);         // MongoDB default is 0, means no timeout
+        builder.readPreference(ReadPreference.secondaryPreferred());    // Will read from secondary if available
         /* By default, the driver ensures that the hostname included in the server’s SSL certificate(s)
          * matches the hostname(s) provided when constructing a MongoClient().
          * sslInvalidHostNameAllowed property helps to toggle the hostname verification, assigned false by default.


### PR DESCRIPTION
Added to leverage the documentDB replica set. If there is no secondary the client will default to reading from the primary. 